### PR TITLE
Add NVIDIA and AMD targets in CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,9 @@ jobs:
           -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
           -DCMAKE_CXX_COMPILER=clang++
           -DENABLE_GRAPHICS=ON
-          -DENABLE_SPIR=ON -DENABLE_CUDA=OFF -DENABLE_HIP=OFF
+          -DENABLE_SPIR=ON
+          -DENABLE_CUDA=ON -DCUDA_COMPUTE_CAPABILITY=80
+          -DENABLE_HIP=ON -DHIP_GFX_ARCH=gfx90a
           -DCMAKE_CXX_FLAGS='-Wall -Wextra -Wpedantic -Werror'
           -G Ninja
 

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -5,14 +5,27 @@ RUN apt update && apt -y install wget gpg git cmake ninja-build \
     gcc-12 libstdc++-12-dev libsdl2-dev \
     && apt clean
 
-# Install Intel oneAPI repositories
+# Install nvcc (dependency for compiling for a CUDA target)
+ARG CUDA_VERSION=12-4
+RUN wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.0-1_all.deb \
+    && dpkg -i cuda-keyring_1.0-1_all.deb && rm cuda-keyring_1.0-1_all.deb \
+    && apt update && apt -y install cuda-nvcc-${CUDA_VERSION} && apt clean
+
+# Install ROCm device libs (dependency for compiling for a HIP target)
+ARG ROCM_VERSION=5.4.3
+RUN wget https://repo.radeon.com/rocm/rocm.gpg.key -O - \
+    | gpg --dearmor | tee /etc/apt/keyrings/rocm.gpg > /dev/null \
+    && echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/${ROCM_VERSION} jammy main" \
+    | tee /etc/apt/sources.list.d/rocm.list \
+    && apt update && apt -y install rocm-device-libs && apt clean
+
+# Install DPC++ and remove parts we don't need to reduce the container size
+ARG ONEAPI_VERSION=2024.1
 RUN wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB \
     | gpg --dearmor | tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null \
     && echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" \
-    | tee /etc/apt/sources.list.d/oneAPI.list
-
-# Install DPC++ and remove parts we don't need to reduce the container size
-RUN apt update && apt -y install intel-oneapi-compiler-dpcpp-cpp-2024.0 \
+    | tee /etc/apt/sources.list.d/oneAPI.list \
+    && apt update && apt -y install intel-oneapi-compiler-dpcpp-cpp-${ONEAPI_VERSION} \
     && apt clean \
     && cd /opt/intel/oneapi \
     && rm -rf conda_channel debugger dev-utilities dpl compiler/latest/linux/lib/oclfpga
@@ -24,6 +37,7 @@ ENV PATH=${CMPLR_ROOT}/bin:${CMPLR_ROOT}/bin/compiler:${PATH}
 ENV CPATH=${CMPLR_ROOT}/include:${CPATH}
 ENV LIBRARY_PATH=${CMPLR_ROOT}/lib:${LIBRARY_PATH}
 ENV LD_LIBRARY_PATH=${CMPLR_ROOT}/lib:${LD_LIBRARY_PATH}
+ENV HIP_DEVICE_LIB_PATH=/usr/lib/x86_64-linux-gnu/amdgcn/bitcode
 
 # Set up entry point
 ENTRYPOINT []


### PR DESCRIPTION
* Add option to specify CUDA/HIP arch tag in CMake arguments
* Add CUDA/HIP target dependencies in Dockerfile
* Add CUDA/HIP targets in the CI build with sm_80/gfx90a archs respectively