### PR TITLE
Create codeql.yml

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,93 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: '16 14 * * 0'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    # Runner size impacts CodeQL analysis time. To learn more, please see:
+    #   - https://gh.io/recommended-hardware-resources-for-running-codeql
+    #   - https://gh.io/supported-runners-and-hardware-resources
+    #   - https://gh.io/using-larger-runners (GitHub.com only)
+    # Consider using larger runners or machines with greater resources for possible analysis time improvements.
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    timeout-minutes: ${{ (matrix.language == 'swift' && 120) || 360 }}
+    permissions:
+      # required for all workflows
+      security-events: write
+
+      # required to fetch internal or private CodeQL packs
+      packages: read
+
+      # only required for workflows in private repositories
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - language: c-cpp
+          build-mode: autobuild
+        # CodeQL supports the following values keywords for 'language': 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift'
+        # Use `c-cpp` to analyze code written in C, C++ or both
+        # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
+        # Use 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
+        # To learn more about changing the languages that are analyzed or customizing the build mode for your analysis,
+        # see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning.
+        # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
+        # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: ${{ matrix.language }}
+        build-mode: ${{ matrix.build-mode }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+
+        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+        # queries: security-extended,security-and-quality
+
+    # If the analyze step fails for one of the languages you are analyzing with
+    # "We were unable to automatically build your code", modify the matrix above
+    # to set the build mode to "manual" for that language. Then modify this step
+    # to build your code.
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+    - if: matrix.build-mode == 'manual'
+      shell: bash
+      run: |
+        echo 'If you are using a "manual" build mode for one or more of the' \
+          'languages you are analyzing, replace this with the commands to build' \
+          'your code, for example:'
+        echo '  make bootstrap'
+        echo '  make release'
+        exit 1
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -59,13 +59,16 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
 
     container:
-      image: ghcr.io/codeplaysoftware/sycl-samples:latest
+      image: intel/oneapi-basekit:latest
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
-      with:
-        submodules: "recursive"
+
+    # Handle git 'dubious ownership/safe.directory' container warnings (reduces related CodeQL verbosity)
+    - name: Add safe Git directory
+      if: matrix.build-mode == 'manual'
+      run: git config --global --add safe.directory /__w/SYCL-samples/SYCL-samples
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
@@ -87,24 +90,21 @@ jobs:
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 
-    # Configure Cmake & Build - inc. graphics
+    # Configure Cmake & Build - no graphics
 
-    - name: Configure CMake
+    - name: Configure CMake (no graphics)
       if: matrix.build-mode == 'manual'
       run: >
         cmake -B ${{github.workspace}}/build
         -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
-        -DCMAKE_CXX_COMPILER=clang++
-        -DENABLE_GRAPHICS=ON
-        -DENABLE_SPIR=ON
-        -DENABLE_CUDA=ON -DCUDA_COMPUTE_CAPABILITY=80
-        -DENABLE_HIP=ON -DHIP_GFX_ARCH=gfx90a
+        -DCMAKE_CXX_COMPILER=icpx
+        -DENABLE_GRAPHICS=OFF
+        -DENABLE_SPIR=ON -DENABLE_CUDA=OFF -DENABLE_HIP=OFF
         -DCMAKE_CXX_FLAGS='-Wall -Wextra -Wpedantic -Werror'
-        -G Ninja
 
-    - name: Build
+    - name: Build (no graphics)
       if: matrix.build-mode == 'manual'
-      run: cmake --build ${{github.workspace}}/build -- -k 0
+      run: cmake --build ${{github.workspace}}/build -- -k -j
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,7 +17,10 @@ on:
   pull_request:
     branches: [ "main" ]
   schedule:
-    - cron: '16 14 * * 0'
+    - cron: '40 8 * * 6'
+
+env:
+  BUILD_TYPE: Release
 
 jobs:
   analyze:
@@ -45,7 +48,7 @@ jobs:
       matrix:
         include:
         - language: c-cpp
-          build-mode: autobuild
+          build-mode: manual
         # CodeQL supports the following values keywords for 'language': 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
@@ -54,9 +57,15 @@ jobs:
         # see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning.
         # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
+
+    container:
+      image: ghcr.io/codeplaysoftware/sycl-samples:latest
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+      with:
+        submodules: "recursive"
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
@@ -77,15 +86,25 @@ jobs:
     # to build your code.
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-    - if: matrix.build-mode == 'manual'
-      shell: bash
-      run: |
-        echo 'If you are using a "manual" build mode for one or more of the' \
-          'languages you are analyzing, replace this with the commands to build' \
-          'your code, for example:'
-        echo '  make bootstrap'
-        echo '  make release'
-        exit 1
+
+    # Configure Cmake & Build - inc. graphics
+
+    - name: Configure CMake
+      if: matrix.build-mode == 'manual'
+      run: >
+        cmake -B ${{github.workspace}}/build
+        -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+        -DCMAKE_CXX_COMPILER=clang++
+        -DENABLE_GRAPHICS=ON
+        -DENABLE_SPIR=ON
+        -DENABLE_CUDA=ON -DCUDA_COMPUTE_CAPABILITY=80
+        -DENABLE_HIP=ON -DHIP_GFX_ARCH=gfx90a
+        -DCMAKE_CXX_FLAGS='-Wall -Wextra -Wpedantic -Werror'
+        -G Ninja
+
+    - name: Build
+      if: matrix.build-mode == 'manual'
+      run: cmake --build ${{github.workspace}}/build -- -k 0
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
Initial Github codeql.yml file. 
Notes:
- Commit 1 is the standard Github version of the file, added for reference.
- By default CodeQL's `autobuild` feature fails for this repo so a 'manual' build (codeql.yml file plus container) is required.
- At time of writing, the CI workflow has >1 build flavours. The chosen flavour represents simplest build showing complete 'manual' CodeQL plumbing.