### PR TITLE
Dependabot PRs to be reviewed by Security managers team

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,5 @@ updates:
       github-actions:
         patterns:
           - "*"
+    reviewers:
+      - "codeplaysoftware/security-managers"


### PR DESCRIPTION
Pull requests opened by dependabot, regarding github actions updates will mention security managers team. 