### PR TITLE
Enable OpenSSF Scorecard badge

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           results_file: results.sarif
           results_format: sarif
-          publish_results: false
+          publish_results: true
 
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # SYCL-samples
+
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/codeplaysoftware/SYCL-samples/badge)](https://scorecard.dev/viewer/?uri=github.com/codeplaysoftware/SYCL-samples)
+
 A collection of samples and graphical demos written using
 [SYCL](https://www.khronos.org/sycl/).
 


### PR DESCRIPTION
With this change the project README file will show the OpenSSF Scorecard badge, similar to this one:

[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/codeplaysoftware/Template-Repo/badge)](https://scorecard.dev/viewer/?uri=github.com/codeplaysoftware/Template-Repo)