### PR TITLE
Enable Coverity scan

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,0 +1,39 @@
+name: Coverity Scan
+
+# We only want to test official release code, not every pull request.
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+
+permissions: read-all
+
+jobs:
+  coverity:
+    runs-on: ubuntu-latest
+    container: ghcr.io/codeplaysoftware/sycl-samples:main
+    steps:
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        with:
+          submodules: "recursive"
+      - name: Configure image
+        run: >
+          apt update && apt install -y curl
+      - name: Configure CMake
+        run: >
+          cmake -B ${{github.workspace}}/build
+          -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+          -DCMAKE_CXX_COMPILER=clang++
+          -DENABLE_GRAPHICS=ON
+          -DENABLE_SPIR=ON
+          -DENABLE_CUDA=ON -DCUDA_COMPUTE_CAPABILITY=80
+          -DENABLE_HIP=ON -DHIP_GFX_ARCH=gfx90a
+          -DCMAKE_CXX_FLAGS='-Wall -Wextra -Wpedantic -Werror'
+          -G Ninja
+      - uses: vapier/coverity-scan-action@2068473c7bdf8c2fb984a6a40ae76ee7facd7a85 # v1.8.0
+        with:
+          email: ${{ secrets.COVERITY_SCAN_EMAIL }}
+          token: ${{ secrets.COVERITY_SCAN_TOKEN }}
+          command: cmake --build ${{github.workspace}}/build -- -k 0
+          working-directory: 'src'


### PR DESCRIPTION
Using the docker image built in the continuous integration workflow (no necessarily in the same run) we run coverity scan on the source code. 