### PR TITLE
Update clang-format include order rules

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,18 +1,13 @@
 BasedOnStyle: Google
+IncludeBlocks: Regroup
 IncludeCategories:
-  - Regex:           '^<sycl/.*>$'
-    Priority:        3
-    SortPriority:    0
-    CaseSensitive:   false
-  - Regex:           '^<.*\.h>'
+  - Regex:           '^".*"'
     Priority:        1
-    SortPriority:    0
-    CaseSensitive:   false
-  - Regex:           '^<.*'
+  - Regex:           '^<sycl/'
     Priority:        2
-    SortPriority:    0
-    CaseSensitive:   false
-  - Regex:           '.*'
+    SortPriority:    3
+  - Regex:           '<[[:alnum:]_/]+\.(h|hpp)>'
+    Priority:        3
+    SortPriority:    2
+  - Regex:           '<^[.]+>'
     Priority:        4
-    SortPriority:    0
-    CaseSensitive:   false

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@
 *.exe
 *.out
 *.app
+
+# folders
+*build*/

--- a/src/fluid/fluid.h
+++ b/src/fluid/fluid.h
@@ -20,14 +20,14 @@
 
 #pragma once
 
+#include <sycl/sycl.hpp>
+
 #include <algorithm>  // std::fill
 #include <cmath>      // std::round
 #include <cstdlib>    // std::size_t
 #include <exception>  // std::exception_ptr
 #include <iostream>   // std::cout, std::endl
 #include <vector>     // std::vector
-
-#include <sycl/sycl.hpp>
 
 // Kernel declarations.
 class fluid_boundary;

--- a/src/fluid/main.cpp
+++ b/src/fluid/main.cpp
@@ -18,6 +18,8 @@
  *
  **************************************************************************/
 
+#include "fluid.h"
+
 #include <Corrade/Containers/StringStlView.h>
 #include <Magnum/GL/DefaultFramebuffer.h>
 #include <Magnum/GL/Mesh.h>
@@ -32,8 +34,6 @@
 #include <Magnum/Trade/MeshData.h>
 
 #include <sycl/sycl.hpp>
-
-#include "fluid.h"
 
 constexpr Magnum::PixelFormat PIXELFORMAT{Magnum::PixelFormat::RGBA8Unorm};
 

--- a/src/game_of_life/main.cpp
+++ b/src/game_of_life/main.cpp
@@ -18,6 +18,8 @@
  *
  **************************************************************************/
 
+#include "sim.hpp"
+
 #include <Magnum/GL/DefaultFramebuffer.h>
 #include <Magnum/GL/Mesh.h>
 #include <Magnum/GL/Texture.h>
@@ -30,12 +32,10 @@
 #include <Magnum/Shaders/FlatGL.h>
 #include <Magnum/Trade/MeshData.h>
 
-#include <chrono>
-#include <thread>
-
 #include <sycl/sycl.hpp>
 
-#include "sim.hpp"
+#include <chrono>
+#include <thread>
 
 constexpr Magnum::PixelFormat PIXELFORMAT{Magnum::PixelFormat::RGBA8Unorm};
 

--- a/src/game_of_life/sim.hpp
+++ b/src/game_of_life/sim.hpp
@@ -20,11 +20,11 @@
 
 #pragma once
 
-#include <random>
+#include "../include/double_buf.hpp"
 
 #include <sycl/sycl.hpp>
 
-#include "../include/double_buf.hpp"
+#include <random>
 
 enum class CellState : unsigned int {
   LIVE = 1,

--- a/src/mandelbrot/main.cpp
+++ b/src/mandelbrot/main.cpp
@@ -18,6 +18,8 @@
  *
  **************************************************************************/
 
+#include "mandel.hpp"
+
 #include <Magnum/GL/DefaultFramebuffer.h>
 #include <Magnum/GL/Mesh.h>
 #include <Magnum/GL/Texture.h>
@@ -31,8 +33,6 @@
 #include <Magnum/Trade/MeshData.h>
 
 #include <sycl/sycl.hpp>
-
-#include "mandel.hpp"
 
 constexpr size_t WIDTH = 800;
 constexpr size_t HEIGHT = 600;

--- a/src/matrix_multiply_omp_compare/matrix-multiply.cpp
+++ b/src/matrix_multiply_omp_compare/matrix-multiply.cpp
@@ -31,7 +31,7 @@
 #include <ctime>
 #include <iostream>
 
-using namespace cl::sycl;
+using namespace sycl;
 
 class mxm_kernel;
 
@@ -112,7 +112,7 @@ inline bool isPowerOfTwo(int x) { return (x & (x - 1)) == 0; }
  * Note that this example only works for powers of two.
  * */
 template <typename T>
-bool local_mxm(cl::sycl::queue& q, T* MA, T* MB, T* MC, int matSize) {
+bool local_mxm(sycl::queue& q, T* MA, T* MB, T* MC, int matSize) {
   // Make sure it is power of two before running
   if (!isPowerOfTwo(matSize)) {
     std::cout << " This example only works with power of two sizes "
@@ -122,7 +122,7 @@ bool local_mxm(cl::sycl::queue& q, T* MA, T* MB, T* MC, int matSize) {
 
   auto device = q.get_device();
   auto maxBlockSize =
-      device.get_info<cl::sycl::info::device::max_work_group_size>();
+      device.get_info<sycl::info::device::max_work_group_size>();
   auto blockSize = prevPowerOfTwo(std::sqrt(maxBlockSize));
   std::cout << " The Device Max Work Group Size is : " << maxBlockSize
             << std::endl;
@@ -325,14 +325,13 @@ int main(int argc, char* argv[]) {
          * to capture potential asynchronous errors. This function will be
          * called every time there is an asynchronous error on the queue (i.e.
          * some error occurs while the queue is executing kernels) and one of
-         * cl::sycl::queue::throw() or cl::sycl::queue::wait_and_throw() is
-         * called. */
+         * sycl::queue::throw() or sycl::queue::wait_and_throw() is called. */
         queue q([&](exception_list eL) {
           try {
             for (auto& e : eL) {
               std::rethrow_exception(e);
             }
-          } catch (cl::sycl::exception e) {
+          } catch (sycl::exception e) {
             std::cout << " An exception has been thrown: " << e.what()
                       << std::endl;
           }

--- a/src/matrix_multiply_omp_compare/matrix-multiply.cpp
+++ b/src/matrix_multiply_omp_compare/matrix-multiply.cpp
@@ -24,7 +24,8 @@
  *  and differences between them.
  *  See block_host for the OpenMP implementation. */
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
+
 #include <chrono>
 #include <cmath>
 #include <ctime>

--- a/src/nbody/InteropGLBuffer.hpp
+++ b/src/nbody/InteropGLBuffer.hpp
@@ -10,6 +10,8 @@
 #define CUDA_GL_INTEROP_API_AVAILABLE 0
 #endif
 
+#include <iostream>
+
 /// @brief Magnum GL Buffer wrapper implementing backend-specific interop to
 /// work directly on OpenGL device buffers instead of using host memory.
 ///

--- a/src/nbody/main.cpp
+++ b/src/nbody/main.cpp
@@ -18,6 +18,9 @@
  *
  **************************************************************************/
 
+#include "InteropGLBuffer.hpp"
+#include "sim.hpp"
+
 #include <Corrade/PluginManager/Manager.h>
 #include <Corrade/Utility/Resource.h>
 #include <Magnum/GL/AbstractShaderProgram.h>
@@ -28,6 +31,7 @@
 #include <Magnum/GL/Texture.h>
 #include <Magnum/GL/TextureFormat.h>
 #include <Magnum/GL/Version.h>
+#include <Magnum/ImGuiIntegration/Context.hpp>
 #include <Magnum/ImageView.h>
 #include <Magnum/Magnum.h>
 #include <Magnum/Math/Angle.h>
@@ -40,14 +44,10 @@
 #include <Magnum/Trade/ImageData.h>
 #include <Magnum/Trade/MeshData.h>
 
-#include <Magnum/ImGuiIntegration/Context.hpp>
-#include <chrono>
-#include <fstream>
-
 #include <sycl/sycl.hpp>
 
-#include "InteropGLBuffer.hpp"
-#include "sim.hpp"
+#include <chrono>
+#include <fstream>
 
 using num_t = float;
 constexpr num_t PI{3.141592653589793238462643383279502884197169399};

--- a/src/nbody/sim.hpp
+++ b/src/nbody/sim.hpp
@@ -20,16 +20,16 @@
 
 #pragma once
 
-#include <iostream>
-#include <memory>
-#include <random>
-
-#include <sycl/sycl.hpp>
-
 #include "../include/double_buf.hpp"
 #include "integrator.hpp"
 #include "sycl_bufs.hpp"
 #include "tuple_utils.hpp"
+
+#include <sycl/sycl.hpp>
+
+#include <iostream>
+#include <memory>
+#include <random>
 
 // Convenience types
 template <typename num_t>

--- a/src/nbody/sycl_bufs.hpp
+++ b/src/nbody/sycl_bufs.hpp
@@ -20,11 +20,11 @@
 
 #pragma once
 
-#include <type_traits>
+#include "tuple_utils.hpp"
 
 #include <sycl/sycl.hpp>
 
-#include "tuple_utils.hpp"
+#include <type_traits>
 
 // Template function object which transforms buffers to device read accessors
 struct BufToReadAccFunc {

--- a/src/nbody/tuple_utils.hpp
+++ b/src/nbody/tuple_utils.hpp
@@ -111,7 +111,7 @@ namespace {
 
   template <typename Tuple, size_t... Ids>
   auto squash_tuple_help(Tuple && tpl, index_sequence<Ids...>)
-      ->decltype(std::make_tuple(std::get<Ids>(std::forward<Tuple>(tpl))...)) {
+      -> decltype(std::make_tuple(std::get<Ids>(std::forward<Tuple>(tpl))...)) {
     return std::make_tuple(std::get<Ids>(std::forward<Tuple>(tpl))...);
   }
 }
@@ -130,9 +130,8 @@ auto squash_tuple(Tuple&& tpl)
 // Adds tuples by calling operator+ elementwise.
 namespace {
 template <typename TupleA, typename TupleB, size_t... Ids>
-auto add_tuples_help(TupleA&& a, TupleB&& b, index_sequence<Ids...>)
-    -> decltype(std::make_tuple(std::get<Ids>(std::forward<TupleA>(a)) +
-                                std::get<Ids>(std::forward<TupleB>(b))...)) {
+auto add_tuples_help(TupleA&& a, TupleB&& b,
+                     index_sequence<Ids...>) -> decltype(auto) {
   return std::make_tuple(std::get<Ids>(std::forward<TupleA>(a)) +
                          std::get<Ids>(std::forward<TupleB>(b))...);
 }
@@ -143,9 +142,7 @@ template <
     size_t SizeA = std::tuple_size<typename std::decay<TupleA>::type>::value,
     size_t SizeB = std::tuple_size<typename std::decay<TupleB>::type>::value,
     typename Ids = make_index_sequence<SizeA>>
-auto add_tuples(TupleA&& a, TupleB&& b)
-    -> decltype(add_tuples_help(std::forward<TupleA>(a),
-                                std::forward<TupleB>(b), Ids{})) {
+auto add_tuples(TupleA&& a, TupleB&& b) -> decltype(auto) {
   static_assert(SizeA == SizeB, "Cannot add tuples of differing sizes.");
   return add_tuples_help(std::forward<TupleA>(a), std::forward<TupleB>(b),
                          Ids{});

--- a/src/nbody/tuple_utils.hpp
+++ b/src/nbody/tuple_utils.hpp
@@ -111,7 +111,7 @@ namespace {
 
   template <typename Tuple, size_t... Ids>
   auto squash_tuple_help(Tuple && tpl, index_sequence<Ids...>)
-      -> decltype(std::make_tuple(std::get<Ids>(std::forward<Tuple>(tpl))...)) {
+      ->decltype(std::make_tuple(std::get<Ids>(std::forward<Tuple>(tpl))...)) {
     return std::make_tuple(std::get<Ids>(std::forward<Tuple>(tpl))...);
   }
 }
@@ -130,8 +130,8 @@ auto squash_tuple(Tuple&& tpl)
 // Adds tuples by calling operator+ elementwise.
 namespace {
 template <typename TupleA, typename TupleB, size_t... Ids>
-auto add_tuples_help(TupleA&& a, TupleB&& b,
-                     index_sequence<Ids...>) -> decltype(auto) {
+auto add_tuples_help(TupleA&& a, TupleB&& b, index_sequence<Ids...>)
+    -> decltype(auto) {
   return std::make_tuple(std::get<Ids>(std::forward<TupleA>(a)) +
                          std::get<Ids>(std::forward<TupleB>(b))...);
 }

--- a/src/scan_parallel_inclusive/scan.cpp
+++ b/src/scan_parallel_inclusive/scan.cpp
@@ -18,7 +18,8 @@
  *
  **************************************************************************/
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
+
 #include <algorithm>
 #include <iostream>
 #include <numeric>


### PR DESCRIPTION
We should be including the sycl.hpp header from the sycl/ folder.